### PR TITLE
Draw Up/Down variations

### DIFF
--- a/toolbox/harryPlotter/Setters.py
+++ b/toolbox/harryPlotter/Setters.py
@@ -69,6 +69,7 @@ class HSSetters:
         self.setErrorbandOnLines()
         self.setScaleLineErrors()
         self.setOnlyPlotErrorGroups()
+        self.setSplitUpDownErrorGroups()
         self.setLineRatios()
 
         self.setRatio()
@@ -109,6 +110,7 @@ class HSSetters:
             printer.printInfo("\tEnabledLineErrors:     {}".format(self.enabledLineErrors))
             printer.printInfo("\tScaleLineErrors:      {}".format(self.scaleLineErrors))
             printer.printInfo("\tOnlyPlotErrorGroups:  {}".format(self.onlyPlotErrorGroups))
+            printer.printInfo("\tSplitUpDownErrorGroups:  {}".format(self.splitUpDownErrorGroups))
         printer.printInfo("\tAddRatio:             {}".format(self.ratio))
         if self.ratio:
             printer.printInfo("\tRatioLabel:           {}".format(self.ratioLabel))
@@ -204,9 +206,11 @@ class HSSetters:
     def setEnabledLineErrors(self, val = []):
         self.enabledLineErrors = val
 
-
     def setOnlyPlotErrorGroups(self, groups = None):
         self.onlyPlotErrorGroups = groups
+
+    def setSplitUpDownErrorGroups(self, groups = None):
+        self.splitUpDownErrorGroups = groups
 
     def setLineRatios(self, val = False):
         self.lineRatios = val


### PR DESCRIPTION
added possibility to harryPlotter to draw up/down variations of syst groups seperately for the full stack

this can be done via the `splitUpDownErrorGroups` setting, which should contain a list of syst groups to be drawen splittet into up and down variations

right now only the variations on the full MC stack are supported

This new feature is also implemented in hogwarts with the corresponding MR:
https://gitlab.cern.ch/kit-cn-cms/hogwarts/-/merge_requests/7
